### PR TITLE
add explain pf key_name parameter for json codec of s3 source

### DIFF
--- a/_data-prepper/pipelines/configuration/sources/s3.md
+++ b/_data-prepper/pipelines/configuration/sources/s3.md
@@ -151,6 +151,12 @@ Option | Required | Type    | Description
 
 The `json` codec parses each S3 object as a single JSON object from a JSON array and then creates a Data Prepper log event for each object in the array.
 
+Use the following options to configure the `json` codec.
+
+Option | Required | Type    | Description
+:--- | :--- |:--------| :---
+`key_name` | No | String  | The name of the input field from which to extract the JSON array and create events.
+
 ### csv codec
 
 The `csv` codec parses objects in comma-separated value (CSV) format, with each row producing a Data Prepper log event. Use the following options to configure the `csv` codec.


### PR DESCRIPTION
### Description
json codec of s3 source supports key_name parameter used by extracting the JSON array and create events, but current doc does not cover it.

https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/s3/#json-codec

### Issues Resolved
#10558

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
